### PR TITLE
Use subcommands instead of args for commands

### DIFF
--- a/cmd/gitmono/diff.go
+++ b/cmd/gitmono/diff.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/jessevdk/go-flags"
+	"github.com/sermojohn/gitmono"
+)
+
+type DiffCommander struct {
+	mono *gitmono.GitMono
+}
+
+type DiffOptions struct {
+	FromRef string `short:"f" description:"The starting point of reference range"`
+	ToRef   string `short:"t" description:"The ending point of reference range"`
+}
+
+func (dc *DiffCommander) Execute(args []string) error {
+	var opts DiffOptions
+	_, err := flags.NewParser(&opts, flags.IgnoreUnknown).Parse()
+	checkError(err)
+
+	differ := gitmono.NewDiffer(dc.mono)
+	projects, err := differ.Diff(opts.FromRef, opts.ToRef)
+	checkError(err)
+	printProjects(projects)
+
+	return nil
+}
+
+func printProjects(projects []string) {
+	for _, project := range projects {
+		fmt.Printf("%s\n", project)
+	}
+}

--- a/cmd/gitmono/log.go
+++ b/cmd/gitmono/log.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"github.com/jessevdk/go-flags"
+	"github.com/sermojohn/gitmono"
+)
+
+type LogCommander struct {
+	mono *gitmono.GitMono
+}
+
+type LogOptions struct {
+	FromRef string `short:"f" description:"The starting point of reference range"`
+	ToRef   string `short:"t" description:"The ending point of reference range"`
+}
+
+func (lc *LogCommander) Execute(args []string) error {
+	var opts LogOptions
+	_, err := flags.NewParser(&opts, flags.IgnoreUnknown).Parse()
+	checkError(err)
+
+	logger := gitmono.NewLogger(lc.mono)
+	commits, err := logger.Log(opts.FromRef, opts.ToRef)
+	checkError(err)
+
+	printCommits(commits)
+	return nil
+}

--- a/cmd/gitmono/main.go
+++ b/cmd/gitmono/main.go
@@ -12,116 +12,57 @@ import (
 	"github.com/sermojohn/gitmono"
 )
 
-// Options holds the CLI args
+// Commands holds the CLI args
+type Commands struct {
+	DiffCommander           DiffCommander           `command:"diff"`
+	LogCommander            LogCommander            `command:"log"`
+	VersionCurrentCommander VersionCurrentCommander `command:"version"`
+	VersionReleaseCommander VersionReleaseCommander `command:"release"`
+	VersionInitCommander    VersionInitCommander    `command:"init"`
+}
 type Options struct {
-	DiffSubcommand    bool     `short:"d" description:"Subcommand to print changed projects for a reference range"`
-	VersionSubcommand bool     `short:"c" description:"Subcommand to print the current version of a project"`
-	ReleaseSubcommand bool     `short:"r" description:"Subcommand to tag & print the release version of a project"`
-	InitSubcommand    bool     `short:"i" description:"Subcommand to tag & print the init version of unintialized project"`
-	LogSubcommand     bool     `short:"l" description:"Subcommand to print the log of commits of a project"`
-	FromRef           string   `short:"f" description:"The starting point of reference range"`
-	ToRef             string   `short:"t" description:"The ending point of reference range"`
-	Projects          []string `short:"p" description:"The list of project directories to account"`
-	Verbose           bool     `short:"v" description:"Enable verbose loggging"`
-	DryRun            bool     `long:"dry-run" description:"Do not persist any write action"`
-	CommitScheme      string   `long:"commit-scheme" description:"The scheme parse commit messages with"`
-	VersionPrefix     string   `long:"version-prefix" description:"The prefix to prepend to version"`
+	Projects      []string `short:"p" description:"The list of project directories to account"`
+	Verbose       bool     `short:"v" description:"Enable verbose loggging"`
+	DryRun        bool     `long:"dry-run" description:"Do not persist any write action"`
+	CommitScheme  string   `long:"commit-scheme" description:"The scheme parse commit messages with"`
+	VersionPrefix string   `long:"version-prefix" description:"The prefix to prepend to version"`
+}
+
+func (opts *Options) Config() *gitmono.Config {
+	return &gitmono.Config{
+		Projects:      opts.Projects,
+		DryRun:        opts.DryRun,
+		CommitScheme:  opts.CommitScheme,
+		VersionPrefix: opts.VersionPrefix,
+	}
 }
 
 func main() {
-	var opts Options
-	_, err := flags.Parse(&opts)
+	mono, err := gitmono.OpenRepo("./")
 	checkError(err)
+
+	var opts Options
+	_, err = flags.NewParser(&opts, flags.IgnoreUnknown).Parse()
+	checkError(err)
+	if len(opts.Projects) == 0 {
+		opts.Projects = []string{"."}
+	}
 
 	log.SetOutput(ioutil.Discard)
 	if opts.Verbose {
 		log.SetOutput(os.Stderr)
 	}
+	mono.SetConfig(opts.Config())
 
-	if len(opts.Projects) == 0 {
-		opts.Projects = []string{"."}
+	var commands = Commands{
+		DiffCommander:           DiffCommander{mono: mono},
+		LogCommander:            LogCommander{mono: mono},
+		VersionCurrentCommander: VersionCurrentCommander{mono: mono},
+		VersionReleaseCommander: VersionReleaseCommander{mono: mono},
+		VersionInitCommander:    VersionInitCommander{mono: mono},
 	}
-
-	mono, err := gitmono.OpenCurrentRepo(&gitmono.Config{
-		Projects:      opts.Projects,
-		DryRun:        opts.DryRun,
-		CommitScheme:  opts.CommitScheme,
-		VersionPrefix: opts.VersionPrefix,
-	})
+	_, err = flags.NewParser(&commands, flags.IgnoreUnknown).Parse()
 	checkError(err)
-
-	if opts.DiffSubcommand {
-		differ := gitmono.NewDiffer(mono)
-
-		projects, err := differ.Diff(opts.FromRef, opts.ToRef)
-		checkError(err)
-
-		printProjects(projects)
-		os.Exit(0)
-	}
-
-	if opts.VersionSubcommand {
-		if len(opts.Projects) != 1 {
-			fmt.Printf("expected single project to be provided")
-			os.Exit(1)
-		}
-
-		versioner := gitmono.NewVersioner(mono)
-		currentVersion, err := versioner.CurrentVersion()
-		checkError(err)
-
-		if currentVersion != nil {
-			printVersion(currentVersion)
-		}
-		os.Exit(0)
-	}
-
-	if opts.ReleaseSubcommand {
-		if len(opts.Projects) != 1 {
-			fmt.Printf("expected single project to be provided")
-			os.Exit(1)
-		}
-
-		versioner := gitmono.NewVersioner(mono)
-		newVersion, err := versioner.NewVersion()
-		checkError(err)
-
-		if newVersion != nil {
-			printVersion(newVersion)
-		}
-		os.Exit(0)
-	}
-
-	if opts.LogSubcommand {
-		if len(opts.Projects) != 1 {
-			fmt.Printf("expected single project to be provided")
-			os.Exit(1)
-		}
-
-		logger := gitmono.NewLogger(mono)
-		commits, err := logger.Log(opts.FromRef, opts.ToRef)
-		checkError(err)
-
-		printCommits(commits)
-		os.Exit(0)
-	}
-
-	if opts.InitSubcommand {
-		versioner := gitmono.NewVersioner(mono)
-		newVersions, err := versioner.InitVersion()
-		checkError(err)
-
-		for _, newVersion := range newVersions {
-			printVersion(newVersion)
-		}
-		os.Exit(0)
-	}
-}
-
-func printProjects(projects []string) {
-	for _, project := range projects {
-		fmt.Printf("%s\n", project)
-	}
 }
 
 func printCommits(commits []*git.Commit) {

--- a/cmd/gitmono/version_current.go
+++ b/cmd/gitmono/version_current.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"github.com/sermojohn/gitmono"
+)
+
+type VersionCurrentCommander struct {
+	mono *gitmono.GitMono
+}
+
+func (vcc *VersionCurrentCommander) Execute(args []string) error {
+	versioner := gitmono.NewVersioner(vcc.mono)
+	currentVersion, err := versioner.CurrentVersion()
+	checkError(err)
+
+	if currentVersion != nil {
+		printVersion(currentVersion)
+	}
+
+	return nil
+}

--- a/cmd/gitmono/version_init.go
+++ b/cmd/gitmono/version_init.go
@@ -1,0 +1,18 @@
+package main
+
+import "github.com/sermojohn/gitmono"
+
+type VersionInitCommander struct {
+	mono *gitmono.GitMono
+}
+
+func (vic *VersionInitCommander) Execute(args []string) error {
+	versioner := gitmono.NewVersioner(vic.mono)
+	newVersions, err := versioner.InitVersion()
+	checkError(err)
+
+	for _, newVersion := range newVersions {
+		printVersion(newVersion)
+	}
+	return nil
+}

--- a/cmd/gitmono/version_release.go
+++ b/cmd/gitmono/version_release.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"github.com/sermojohn/gitmono"
+)
+
+type VersionReleaseCommander struct {
+	mono *gitmono.GitMono
+}
+
+func (vrc *VersionReleaseCommander) Execute(args []string) error {
+	versioner := gitmono.NewVersioner(vrc.mono)
+	newVersion, err := versioner.NewVersion()
+	checkError(err)
+
+	if newVersion != nil {
+		printVersion(newVersion)
+	}
+	return nil
+}

--- a/diff.go
+++ b/diff.go
@@ -26,8 +26,8 @@ func (d *Differ) Diff(from, to string) ([]string, error) {
 		return nil, err
 	}
 
-	diffedProjects := make([]string, 0, len(d.mono.projects))
-	diffedProjectsIndex := make(map[string]struct{}, len(d.mono.projects))
+	diffedProjects := make([]string, 0, len(d.mono.config.Projects))
+	diffedProjectsIndex := make(map[string]struct{}, len(d.mono.config.Projects))
 	for _, file := range diffRes.Files {
 		if project, matched := d.matchFile(file.Name); matched {
 			if _, ok := diffedProjectsIndex[project]; !ok {
@@ -40,7 +40,7 @@ func (d *Differ) Diff(from, to string) ([]string, error) {
 }
 
 func (d *Differ) matchFile(name string) (string, bool) {
-	for _, project := range d.mono.projects {
+	for _, project := range d.mono.config.Projects {
 		if project == "." || strings.HasPrefix(name, project) {
 			return project, true
 		}

--- a/gitmono.go
+++ b/gitmono.go
@@ -6,13 +6,11 @@ import (
 
 // GitMono contains repository instance and command parameters
 type GitMono struct {
-	repo          *git.Repository
-	projects      []string
-	dryRun        bool
-	commitScheme  string
-	versionPrefix string
+	repo   *git.Repository
+	config Config
 }
 
+// Config defines generic configuration applying to multiple commands
 type Config struct {
 	Projects      []string
 	DryRun        bool
@@ -20,19 +18,20 @@ type Config struct {
 	VersionPrefix string
 }
 
-func OpenCurrentRepo(config *Config) (*GitMono, error) {
+// OpenRepo open a git repository and returns the monorepo wrapper
+func OpenRepo(path string) (*GitMono, error) {
 	repo, err := git.Open("./")
 	if err != nil {
 		return nil, err
 	}
 
 	monorepo := GitMono{
-		repo:          repo,
-		projects:      config.Projects,
-		dryRun:        config.DryRun,
-		commitScheme:  config.CommitScheme,
-		versionPrefix: config.VersionPrefix,
+		repo: repo,
 	}
 
 	return &monorepo, nil
+}
+
+func (m *GitMono) SetConfig(config *Config) {
+	m.config = *config
 }

--- a/log.go
+++ b/log.go
@@ -15,12 +15,12 @@ func NewLogger(mono *GitMono) *Logger {
 }
 
 func (l *Logger) Log(from, to string) ([]*git.Commit, error) {
-	if len(l.mono.projects) != 1 {
+	if len(l.mono.config.Projects) != 1 {
 		return nil, fmt.Errorf("expected single project")
 	}
 
 	return l.mono.repo.Log(fmt.Sprintf("%s..%s", from, to), git.LogOptions{
-		Path: l.mono.projects[0],
+		Path: l.mono.config.Projects[0],
 	})
 }
 


### PR DESCRIPTION
Use diff, log, version, release, init commands instead of flags.